### PR TITLE
feat(grupo): toggle de vista con persistencia

### DIFF
--- a/src/components/mosaico/MosaicoView.tsx
+++ b/src/components/mosaico/MosaicoView.tsx
@@ -1,11 +1,20 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { View, Text, FlatList, Pressable, Modal, StyleSheet, RefreshControl } from "react-native";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  Modal,
+  StyleSheet,
+  RefreshControl,
+} from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 type Materia = { id: string; nombre: string };
 type Tarea = { id: string; titulo: string; venceEn?: string; done?: boolean };
+type Props = { groupId: string };
 
-export default function MosaicoView({ groupId }: { groupId: string }) {
+export default function MosaicoView({ groupId }: Props) {
   const [materias, setMaterias] = useState<Materia[]>([]);
   const [loading, setLoading] = useState(false);
   const [sel, setSel] = useState<Materia | null>(null);

--- a/src/lib/storage/groupStyle.ts
+++ b/src/lib/storage/groupStyle.ts
@@ -1,0 +1,25 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type GroupStyle = "mosaico" | "kanban";
+
+const key = (id: string) => `groupStyle:${id}`;
+
+export async function getGroupStyle(groupId: string): Promise<GroupStyle | null> {
+  try {
+    const stored = await AsyncStorage.getItem(key(groupId));
+    if (stored === "mosaico" || stored === "kanban") {
+      return stored;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export async function setGroupStyle(groupId: string, style: GroupStyle): Promise<void> {
+  try {
+    await AsyncStorage.setItem(key(groupId), style);
+  } catch {
+    // ignore
+  }
+}

--- a/src/screens/grupo.tsx
+++ b/src/screens/grupo.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { View, Text, Pressable, Modal, StyleSheet } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import KanbanView from "../components/kanban/kanban_view";
 import MosaicoView from "../components/mosaico/MosaicoView";
+import {
+  type GroupStyle,
+  getGroupStyle,
+  setGroupStyle,
+} from "../lib/storage/groupStyle";
 
-type GroupStyle = "mosaico" | "kanban";
-type Props = { route: { params: { groupId: string; nombre?: string } } };
-
-const STYLE_KEY = (id: string) => `group_style:${id}`;
+interface RouteParams { groupId: string; nombre?: string }
+interface Props { route?: { params?: RouteParams } }
 
 export default function Grupo({ route }: Props) {
   const groupId = route?.params?.groupId ?? "default";
@@ -17,17 +19,15 @@ export default function Grupo({ route }: Props) {
 
   useEffect(() => {
     (async () => {
-      try {
-        const s = await AsyncStorage.getItem(STYLE_KEY(groupId));
-        if (s === "mosaico" || s === "kanban") setViewStyle(s);
-      } catch {}
+      const s = await getGroupStyle(groupId);
+      if (s) setViewStyle(s);
     })();
   }, [groupId]);
 
   const applyStyle = async (s: GroupStyle) => {
     setViewStyle(s);
     setMenuOpen(false);
-    try { await AsyncStorage.setItem(STYLE_KEY(groupId), s); } catch {}
+    await setGroupStyle(groupId, s);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add async-storage helper for per-group view style
- toggle between Kanban and Mosaico with persisted preference
- clean up view components and wire Kanban view to group prop

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

## Checklist
- [x] Botón en header derecho junto a "cirh"
- [x] Menú con "Mosaico" y "Kanban"
- [x] Cambia la vista al vuelo y persiste al reabrir
- [x] Default = "Mosaico" si no existe valor


------
https://chatgpt.com/codex/tasks/task_e_689811757564832ebc1c2b102ff473eb