### PR TITLE
feat: add view style toggle with mosaico store integration

### DIFF
--- a/src/components/kanban/add_action.tsx
+++ b/src/components/kanban/add_action.tsx
@@ -2,16 +2,16 @@
 import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { Modalize } from 'react-native-modalize'
-import { IHandles } from 'react-native-modalize/lib/options'
+import type { IHandles } from 'react-native-modalize/lib/options'
 
-interface AddActionSheetProps {
-    modalRef: React.RefObject<IHandles>
+type Props = {
+    modalRef: React.RefObject<IHandles | null>
     onCrearMateria: () => void
     onCrearTarea?: () => void
     mostrarCrearTarea: boolean
 }
 
-const AddActionSheet: React.FC<AddActionSheetProps> = ({ modalRef, onCrearMateria, onCrearTarea, mostrarCrearTarea }) => {
+const AddActionSheet: React.FC<Props> = ({ modalRef, onCrearMateria, onCrearTarea, mostrarCrearTarea }) => {
     return (
         <Modalize
             ref={modalRef}

--- a/src/components/kanban/kanban_view.tsx
+++ b/src/components/kanban/kanban_view.tsx
@@ -1,28 +1,28 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { IHandles } from "react-native-modalize/lib/options";
 import { View, Alert, ScrollView, TouchableOpacity, Text, StyleSheet } from "react-native";
-import { Tarea } from "../../models/types";
+import type { Tarea } from "../../models/types";
 import { useAppStore } from "../../store/useAppStore";
 import KanbanTaskCard from "./kanban_taskcard";
 import TaskBottomSheet from "./task_creation_modal";
 import MateriaModal from "./create-materia";
 import AddActionSheet from "./add_action";
 
-type Props = { groupId: string };
+type Props = { groupId?: string };
 
 export default function KanbanView({ groupId }: Props) {
-  const modalRef = useRef<IHandles>(null!);
-  const addSheetRef = useRef<IHandles>(null!);
+  const gidFromStore = useAppStore(s => s.grupoSeleccionadoId);
+  const gid = groupId ?? gidFromStore ?? "";
+  const setSelectedGroup = useAppStore(s => s.setGrupoSeleccionadoId);
+  useEffect(() => { if (gid) setSelectedGroup(gid); }, [gid, setSelectedGroup]);
+
+  const modalRef = useRef<IHandles | null>(null);
+  const addSheetRef = useRef<IHandles | null>(null);
 
   const [editingTask, setEditingTask] = useState<Tarea | null>(null);
   const [isMateriaModalVisible, setIsMateriaModalVisible] = useState(false);
 
-  const setSelectedGroup = useAppStore((s) => s.setGrupoSeleccionadoId);
-  useEffect(() => {
-    setSelectedGroup(groupId);
-  }, [groupId, setSelectedGroup]);
-
-  const grupo = useAppStore((s) => s.grupos.find((g) => g.id === groupId));
+  const grupo = useAppStore((s) => s.grupos.find((g) => g.id === gid));
   const materias = grupo?.materias || [];
   const usuario = useAppStore((s) => s.usuarioActivo);
 
@@ -38,7 +38,7 @@ export default function KanbanView({ groupId }: Props) {
         text: "Eliminar",
         style: "destructive",
         onPress: () => {
-        useAppStore.getState().deleteTask(groupId, tareaId);
+        useAppStore.getState().deleteTask(gid, tareaId);
         },
       },
     ]);
@@ -47,7 +47,7 @@ export default function KanbanView({ groupId }: Props) {
   const handleToggleTaskStatus = (tareaId: string, currentStatus: string) => {
     if (!usuario) return;
     const newStatus = currentStatus === "pendiente" ? "completada" : "pendiente";
-    useAppStore.getState().updateTaskStatus(groupId, tareaId, usuario.id, newStatus);
+    useAppStore.getState().updateTaskStatus(gid, tareaId, usuario.id, newStatus);
   };
 
   const handleAddTask = () => {

--- a/src/components/kanban/task_creation_modal.tsx
+++ b/src/components/kanban/task_creation_modal.tsx
@@ -11,17 +11,17 @@ import {
 } from 'react-native'
 import DateTimePickerModal from 'react-native-modal-datetime-picker'
 import { Modalize } from 'react-native-modalize'
-import { IHandles } from 'react-native-modalize/lib/options'
+import type { IHandles } from 'react-native-modalize/lib/options'
 import { useAppStore } from '../../store/useAppStore'
-import { Tarea } from '../../models/types'
+import type { Tarea } from '../../models/types'
 
-interface TaskBottomSheetProps {
-    modalRef: React.RefObject<IHandles>
+type Props = {
+    modalRef: React.RefObject<IHandles | null>
     onSave: (tarea: Partial<Tarea>) => void
     editingTask?: Tarea | null
 }
 
-const TaskBottomSheet: React.FC<TaskBottomSheetProps> = ({ modalRef, onSave, editingTask }) => {
+const TaskBottomSheet: React.FC<Props> = ({ modalRef, onSave, editingTask }) => {
     const [titulo, setTitulo] = useState('')
     const [descripcion, setDescripcion] = useState('')
     const [tipo, setTipo] = useState<'tarea' | 'examen' | 'evento' | 'recordatorio'>('tarea')
@@ -85,7 +85,7 @@ const TaskBottomSheet: React.FC<TaskBottomSheetProps> = ({ modalRef, onSave, edi
             ref={modalRef}
             adjustToContentHeight
             keyboardAvoidingBehavior="padding"
-            onClosed={resetForm} // ✅ se ejecuta cuando el modal se cierra completamente
+            onClosed={resetForm}
         >
             <View style={styles.container}>
                 <Text style={styles.title}>{editingTask ? 'Editar Tarea' : 'Nueva Tarea'}</Text>

--- a/src/lib/storage/groupStyle.ts
+++ b/src/lib/storage/groupStyle.ts
@@ -1,25 +1,13 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export type GroupStyle = "mosaico" | "kanban";
+const key = (id: string) => `group_style:${id}`;
 
-const key = (id: string) => `groupStyle:${id}`;
-
-export async function getGroupStyle(groupId: string): Promise<GroupStyle | null> {
-  try {
-    const stored = await AsyncStorage.getItem(key(groupId));
-    if (stored === "mosaico" || stored === "kanban") {
-      return stored;
-    }
-  } catch {
-    // ignore
-  }
-  return null;
+export async function getGroupStyle(id: string): Promise<GroupStyle | null> {
+  const v = await AsyncStorage.getItem(key(id));
+  return v === "mosaico" || v === "kanban" ? v : null;
 }
 
-export async function setGroupStyle(groupId: string, style: GroupStyle): Promise<void> {
-  try {
-    await AsyncStorage.setItem(key(groupId), style);
-  } catch {
-    // ignore
-  }
+export async function setGroupStyle(id: string, s: GroupStyle) {
+  await AsyncStorage.setItem(key(id), s);
 }

--- a/src/screens/grupo.tsx
+++ b/src/screens/grupo.tsx
@@ -1,19 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, Pressable, Modal, StyleSheet } from "react-native";
+import { SafeAreaView, StyleSheet, Pressable, Modal, View, Text } from "react-native";
 import KanbanView from "../components/kanban/kanban_view";
 import MosaicoView from "../components/mosaico/MosaicoView";
-import {
-  type GroupStyle,
-  getGroupStyle,
-  setGroupStyle,
-} from "../lib/storage/groupStyle";
+import { getGroupStyle, setGroupStyle, GroupStyle } from "../lib/storage/groupStyle";
 
-interface RouteParams { groupId: string; nombre?: string }
-interface Props { route?: { params?: RouteParams } }
-
-export default function Grupo({ route }: Props) {
+export default function Grupo({ route }: any) {
   const groupId = route?.params?.groupId ?? "default";
-  const title = route?.params?.nombre ?? "Grupo";
   const [viewStyle, setViewStyle] = useState<GroupStyle>("mosaico");
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -31,39 +23,23 @@ export default function Grupo({ route }: Props) {
   };
 
   return (
-    <View style={{ flex: 1 }}>
-      {/* Header propio porque dijiste que no usas navigator */}
-      <View style={styles.header}>
-        <Text style={styles.title}>{title}</Text>
-        <View style={styles.right}>
-          <Text style={styles.user}>cirh</Text>
-          <Pressable
-            onPress={() => setMenuOpen(true)}
-            style={({ pressed }) => [styles.iconBtn, pressed && { opacity: 0.7 }]}
-            android_ripple={{ color: "#00000022", borderless: true }}
-          >
-            <Text style={styles.icon}>⋮</Text>
-          </Pressable>
-        </View>
-      </View>
+    <SafeAreaView style={styles.container} key={viewStyle}>
+      {viewStyle === "kanban" ? <KanbanView /> : <MosaicoView groupId={groupId} />}
 
-      {viewStyle === "kanban"
-        ? <KanbanView groupId={groupId} />
-        : <MosaicoView groupId={groupId} />}
+      <Pressable onPress={() => setMenuOpen(true)} style={styles.fab}>
+        <Text style={{ fontSize: 20 }}>⋮</Text>
+      </Pressable>
 
-      {/* Menú */}
       <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={() => setMenuOpen(false)}>
         <Pressable style={styles.backdrop} onPress={() => setMenuOpen(false)} />
         <View style={styles.menu}>
           <Text style={styles.menuTitle}>Vista de tareas</Text>
-
           <Pressable style={styles.menuItem} onPress={() => applyStyle("mosaico")}>
             <View style={styles.row}>
               <View style={[styles.radio, viewStyle === "mosaico" && styles.radioOn]} />
               <Text style={styles.menuText}>Mosaico</Text>
             </View>
           </Pressable>
-
           <Pressable style={styles.menuItem} onPress={() => applyStyle("kanban")}>
             <View style={styles.row}>
               <View style={[styles.radio, viewStyle === "kanban" && styles.radioOn]} />
@@ -72,27 +48,15 @@ export default function Grupo({ route }: Props) {
           </Pressable>
         </View>
       </Modal>
-    </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  header: {
-    height: 56, paddingHorizontal: 16, flexDirection: "row",
-    alignItems: "center", justifyContent: "space-between",
-    borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: "#ddd", backgroundColor: "#fff",
-  },
-  title: { fontSize: 18, fontWeight: "600" },
-  right: { flexDirection: "row", alignItems: "center", gap: 8 },
-  user: { fontSize: 14, color: "#555" },
-  iconBtn: { padding: 6, borderRadius: 16 },
-  icon: { fontSize: 20 },
-  backdrop: { position: "absolute", left: 0, right: 0, top: 0, bottom: 0, backgroundColor: "#00000033" },
-  menu: {
-    position: "absolute", top: 58, right: 12, minWidth: 200, borderRadius: 12,
-    backgroundColor: "#fff", paddingVertical: 8, elevation: 8,
-    shadowColor: "#000", shadowOpacity: 0.2, shadowRadius: 12, shadowOffset: { width: 0, height: 6 },
-  },
+  container: { flex: 1, backgroundColor: "#F8F9FA" },
+  fab: { position: "absolute", top: 8, right: 12, padding: 8, borderRadius: 16, backgroundColor: "#fff", elevation: 4, zIndex: 50 },
+  backdrop: { position: "absolute", left: 0, right: 0, top: 0, bottom: 0, backgroundColor: "#0003" },
+  menu: { position: "absolute", top: 44, right: 12, minWidth: 200, borderRadius: 12, backgroundColor: "#fff", paddingVertical: 8, elevation: 8 },
   menuTitle: { fontSize: 12, color: "#666", paddingHorizontal: 12, paddingBottom: 6 },
   menuItem: { paddingHorizontal: 12, paddingVertical: 10 },
   menuText: { fontSize: 16 },


### PR DESCRIPTION
## Summary
- persist per-group view style selection in AsyncStorage
- toggle between kanban and mosaico in group screen
- connect mosaico view to app store and reuse kanban modals

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx expo start -c`

------
https://chatgpt.com/codex/tasks/task_e_68981cc7f3dc832ea0ee7288f198e7f1